### PR TITLE
Update the buildpack to conform to the latest Heroku API

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -106,6 +106,12 @@ else
   cp -r $CACHE_DIR/bin/* $BUILD_DIR/nginx/
 fi
 
+# Update the PATH
+mkdir -p $BUILD_DIR/.profile.d
+cat > $BUILD_DIR/.profile.d/nginx.sh <<"EOF"
+export PATH="$PATH:$HOME/nginx"
+EOF
+
 cd $CUR_DIR
 
 # build nginx config unless overridden by user

--- a/bin/release
+++ b/bin/release
@@ -5,8 +5,6 @@ cat <<EOF
 ---
 
 addons:
-config_vars:
-  PATH: /usr/local/bin:/usr/bin:/bin:/app/nginx
 default_process_types:
   web: /app/start_nginx
 EOF


### PR DESCRIPTION
Heroku has deprecated the config_vars key in .release a long time ago and recommends settings config vars using a shell script in `.profile.d`. Buildstep/Dokku is deprecating support in the near future as well.

Documentation is here:
* `.release` example: https://devcenter.heroku.com/articles/buildpack-api#bin-release-example
* Default config values: https://devcenter.heroku.com/articles/buildpack-api#default-config-values

This PR updates `bin/compile` to create the recommended file and removes the config_vars key from the `.release` file.
