### PR TITLE
Now copying app.json from www/ into $BUILD_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,7 @@ if [[ ! -e "$BUILD_DIR/www" ]]; then
   [[ -f "$BUILD_DIR/www/nginx.conf.erb" ]] && mv $BUILD_DIR/www/nginx.conf.erb $BUILD_DIR
   [[ -f "$BUILD_DIR/www/mime.types" ]] && mv $BUILD_DIR/www/mime.types $BUILD_DIR
   [[ -f "$BUILD_DIR/www/CHECKS" ]] && mv $BUILD_DIR/www/CHECKS $BUILD_DIR
+  [[ -f "$BUILD_DIR/www/app.json" ]] && mv $BUILD_DIR/www/app.json $BUILD_DIR
   rm -rf $CACHE_DIR/www
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -83,7 +83,6 @@ if [[ ! -f "${CACHE_DIR}/bin/nginx" ]]; then
     --without-http_map_module \
     --without-http_split_clients_module \
     --without-http_referer_module \
-    --without-http_proxy_module \
     --without-http_fastcgi_module \
     --without-http_uwsgi_module \
     --without-http_scgi_module \

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,7 @@ NGINX_VERSION="1.8.1"
 NGINX_TARBALL="nginx-${NGINX_VERSION}.tar.gz"
 PCRE_VERSION="8.39"
 PCRE_TARBALL="pcre-${PCRE_VERSION}.tar.gz"
-ZLIB_VERSION="1.2.10"
+ZLIB_VERSION="1.2.11"
 ZLIB_TARBALL="zlib-${ZLIB_VERSION}.tar.gz"
 
 # parse and derive params

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ fi
 
 if [[ ! -d "${PCRE_TARBALL%.tar.gz}" ]]; then
   echo "-----> download and unzip pcre"
-  curl "http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
+  curl "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
   tar xzf "${PCRE_TARBALL}" && rm -f "${PCRE_TARBALL}"
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ set -o pipefail
 # Nginx 1.8.1
 NGINX_VERSION="1.8.1"
 NGINX_TARBALL="nginx-${NGINX_VERSION}.tar.gz"
-PCRE_VERSION="8.38"
+PCRE_VERSION="8.39"
 PCRE_TARBALL="pcre-${PCRE_VERSION}.tar.gz"
 ZLIB_VERSION="1.2.10"
 ZLIB_TARBALL="zlib-${ZLIB_VERSION}.tar.gz"


### PR DESCRIPTION
This allows the use of, amongst other options, post/pre deploy scripts. 

Useful for apps that require a tiny build process (through gulp or grunt, for example)
