### PR TITLE
Update Zlib to version 1.2.10

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,7 @@ NGINX_VERSION="1.8.1"
 NGINX_TARBALL="nginx-${NGINX_VERSION}.tar.gz"
 PCRE_VERSION="8.38"
 PCRE_TARBALL="pcre-${PCRE_VERSION}.tar.gz"
-ZLIB_VERSION="1.2.8"
+ZLIB_VERSION="1.2.10"
 ZLIB_TARBALL="zlib-${ZLIB_VERSION}.tar.gz"
 
 # parse and derive params


### PR DESCRIPTION
Zlib 1.2.8 is no more available via the provided URL.

This PR upgrade Zlib to v1.2.10.
It has been successfully tested.