### PR TITLE
Build packs http request issue fix

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ fi
 
 if [[ ! -d "${PCRE_TARBALL%.tar.gz}" ]]; then
   echo "-----> download and unzip pcre"
-  curl "http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
+  curl "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
   tar xzf "${PCRE_TARBALL}" && rm -f "${PCRE_TARBALL}"
 fi
 


### PR DESCRIPTION
Buildpack fails due to requesting ftp through http.   
Building throw `failed to connect to ftp.csx.cam.ac.uk` error. This PR replaces protocols.